### PR TITLE
Chunk Builder World Access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 loom {
-    accessWidenerPath = file("src/main/resources/better-snow-coverag.accesswidener")
+    accessWidenerPath = file("src/main/resources/better-snow-coverage.accesswidener")
 }
 
 dependencies {

--- a/src/main/java/tobinio/bettersnowcoverage/BetterSnowChecker.java
+++ b/src/main/java/tobinio/bettersnowcoverage/BetterSnowChecker.java
@@ -2,6 +2,7 @@ package tobinio.bettersnowcoverage;
 
 import net.minecraft.block.*;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.chunk.ChunkRendererRegion;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.TagKey;
@@ -31,25 +32,18 @@ public class BetterSnowChecker {
         NONE, WITH_LAYER, WITHOUT_LAYER,
     }
 
-    public static SnowState shouldHaveSnow(BlockPos pos) {
-        ClientWorld world = MinecraftClient.getInstance().world;
+    public static SnowState shouldHaveSnowAboveBlock(ChunkRendererRegion chunkRendererRegion, BlockPos pos) {
+        var state = chunkRendererRegion.getBlockState(pos.up());
 
-        if (world == null) {
-            BetterSnowCoverage.LOGGER.warn("no player found");
+        if (state.isSideSolidFullSquare(chunkRendererRegion, pos, Direction.DOWN) || state.isAir() || state.getBlock() == Blocks.WATER) {
             return SnowState.NONE;
         }
 
-        var state = world.getBlockState(pos);
-
-        if (state.isSideSolidFullSquare(world, pos, Direction.DOWN) || state.isAir() || state.getBlock() == Blocks.WATER) {
+        if (!chunkRendererRegion.getBlockState(pos.down()).isFullCube(chunkRendererRegion, pos.down())) {
             return SnowState.NONE;
         }
 
-        if (!world.getBlockState(pos.down()).isFullCube(world, pos.down())) {
-            return SnowState.NONE;
-        }
-
-        if (hasSnowNeighbor(pos, world)) {
+        if (hasSnowNeighbor(chunkRendererRegion, pos)) {
             if (isExcludedBlock(state)) {
                 return SnowState.WITHOUT_LAYER;
             }
@@ -76,7 +70,7 @@ public class BetterSnowChecker {
         return false;
     }
 
-    private static boolean hasSnowNeighbor(BlockPos pos, ClientWorld world) {
+    private static boolean hasSnowNeighbor(ChunkRendererRegion chunkRendererRegion, BlockPos pos) {
         var directionCheckers = new ArrayList<DirectionChecker>();
         directionCheckers.add(new DirectionChecker(Direction.NORTH, pos));
         directionCheckers.add(new DirectionChecker(Direction.EAST, pos));
@@ -89,7 +83,7 @@ public class BetterSnowChecker {
             var results = new ArrayList<Optional<DirectionChecker.Result>>();
 
             for (DirectionChecker directionChecker : directionCheckers) {
-                Optional<DirectionChecker.Result> result = directionChecker.next(world);
+                Optional<DirectionChecker.Result> result = directionChecker.next(chunkRendererRegion);
                 results.add(result);
             }
 
@@ -125,11 +119,11 @@ public class BetterSnowChecker {
             this.lastPos = pos;
         }
 
-        public Optional<Result> next(ClientWorld world) {
+        public Optional<Result> next(ChunkRendererRegion chunkRendererRegion) {
             lastPos = lastPos.add(direction.getOffsetX(), 0, direction.getOffsetZ());
 
             var maxDepth = 2;
-            while (!world.getBlockState(lastPos).isFullCube(world, lastPos)) {
+            while (!chunkRendererRegion.getBlockState(lastPos).isFullCube(chunkRendererRegion, lastPos)) {
                 if (maxDepth-- < 0) {
                     return Optional.of(Result.UNDEFINED);
                 }
@@ -137,7 +131,7 @@ public class BetterSnowChecker {
                 lastPos = lastPos.down();
             }
 
-            while (world.getBlockState(lastPos.up()).isFullCube(world, lastPos.up())) {
+            while (chunkRendererRegion.getBlockState(lastPos.up()).isFullCube(chunkRendererRegion, lastPos.up())) {
                 if (maxDepth-- < 0) {
                     return Optional.of(Result.UNDEFINED);
                 }
@@ -145,11 +139,11 @@ public class BetterSnowChecker {
                 lastPos = lastPos.up();
             }
 
-            if (world.getBlockState(lastPos.up()).isIn(BlockTags.SNOW)) {
+            if (chunkRendererRegion.getBlockState(lastPos.up()).isIn(BlockTags.SNOW)) {
                 return Optional.of(Result.SNOW);
             }
 
-            if (world.getBlockState(lastPos.up()).isAir()) {
+            if (chunkRendererRegion.getBlockState(lastPos.up()).isAir()) {
                 return Optional.of(Result.NONE);
             }
 

--- a/src/main/java/tobinio/bettersnowcoverage/mixin/ChunkBuilderMixin.java
+++ b/src/main/java/tobinio/bettersnowcoverage/mixin/ChunkBuilderMixin.java
@@ -49,8 +49,8 @@ public class ChunkBuilderMixin {
     }
 
     @ModifyVariable (method = "render", at = @At ("STORE"), ordinal = 0)
-    private BlockState setGrassState(BlockState state, @Local (ordinal = 2) BlockPos blockPos) {
-        var snowState = BetterSnowChecker.shouldHaveSnow(blockPos.up());
+    private BlockState setGrassState(BlockState state, @Local (ordinal = 2) BlockPos blockPos,  @Local (ordinal = 0) ChunkRendererRegion chunkRendererRegion) {
+        var snowState = BetterSnowChecker.shouldHaveSnowAboveBlock(chunkRendererRegion, blockPos);
 
         if (snowState != BetterSnowChecker.SnowState.NONE) {
             return BetterSnowChecker.getSnowState(state);

--- a/src/main/java/tobinio/bettersnowcoverage/mixin/ChunkBuilderMixin.java
+++ b/src/main/java/tobinio/bettersnowcoverage/mixin/ChunkBuilderMixin.java
@@ -32,7 +32,7 @@ public class ChunkBuilderMixin {
             @Local (ordinal = 2) BlockPos blockPos, @Local MatrixStack matrixStack, @Local BufferBuilder bufferBuilder,
             @Local Random random, @Local BlockRenderManager blockRenderManager, @Local ChunkRendererRegion chunkRendererRegion) {
 
-        var snowState = BetterSnowChecker.shouldHaveSnow(blockPos.up());
+        var snowState = BetterSnowChecker.shouldHaveSnowAboveBlock(chunkRendererRegion, blockPos);
 
         if (snowState == BetterSnowChecker.SnowState.WITH_LAYER) {
             matrixStack.push();

--- a/src/main/java/tobinio/bettersnowcoverage/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/tobinio/bettersnowcoverage/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
@@ -30,7 +30,7 @@ public class ChunkBuilderMeshingTaskMixin {
             CallbackInfoReturnable<ChunkBuildOutput> cir, @Local BlockRenderContext ctx,
             @Local ChunkBuildBuffers buffers, @Local BlockRenderCache cache, @Local WorldSlice slice,
             @Local (ordinal = 1) BlockPos.Mutable modelOffset) {
-        BetterSnowChecker.SnowState snowState = BetterSnowChecker.shouldHaveSnow(ctx.pos().up());
+        BetterSnowChecker.SnowState snowState = BetterSnowChecker.shouldHaveSnowAboveBlock(ctx.world(), ctx.pos());
 
         if (snowState != BetterSnowChecker.SnowState.NONE) {
             var newState = BetterSnowChecker.getSnowState(ctx.state());


### PR DESCRIPTION
These are the changes I made to be able to use *Better Snow Coverage* in our mod pack again. I effectively replaced everything that used to be off-thread world access with the supplied `ChunkRendererRegion`. Of course this depends on the region data provided to be accurate. From the last few play sessions, some in snowy regions, it seems fine, though I'm probably not aware of all the places to look like you do.

I'm opening this against the `1.20.1` branch because that's the only version I'm playing on.